### PR TITLE
Update Go version to 1.22.3 in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sensiblecodeio/escape
 
-go 1.19
+go 1.22.3


### PR DESCRIPTION
Specify a point version to placate CodeQL.

We can review if this continues to be necessary.